### PR TITLE
fix: fire of unknown origin name & weight

### DIFF
--- a/realWeights.json
+++ b/realWeights.json
@@ -87,7 +87,7 @@
 "Eternal Bonds":29,
 "Ever-Changing":0,
 "Fateful Meeting":14,
-"Fire of Unknown Origin":0,
+"Fire Of Unknown Origin":11,
 "Forbidden Power":2042,
 "Friendship":0,
 "From Bone to Ashes":207,

--- a/realWeights.json
+++ b/realWeights.json
@@ -87,7 +87,7 @@
 "Eternal Bonds":29,
 "Ever-Changing":0,
 "Fateful Meeting":14,
-"Fire Of Unknown Origin":11,
+"Fire Of Unknown Origin":10,
 "Forbidden Power":2042,
 "Friendship":0,
 "From Bone to Ashes":207,


### PR DESCRIPTION
Weight source: https://discord.com/channels/991073626721763429/991092253445464135/1152134566161698846

Name should be fixed this way, rather than editing `cards.json`, as freshly pulled data will revert `cards.json` to `Fire Of` rather than keeping it `Fire of`